### PR TITLE
fix(twisty): Make twisty widget recompile contents

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,6 +16,7 @@ module.exports = function (config) {
 
         // list of files / patterns to load in the browser
         files: [
+            'node_modules/jquery/dist/jquery.js',
             'node_modules/angular/angular.js',
             'node_modules/angular-mocks/angular-mocks.js',
             dirs.src + '/**/*.module.js',

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-uglify": "^1.5.3",
     "istanbul": "^0.4.3",
     "jasmine-core": "^2.4.1",
+    "jquery": "^3.1.1",
     "jshint": "^2.9.2",
     "karma": "0.13.9",
     "karma-chrome-launcher": "^1.0.1",

--- a/src/twisty/twisty.directive.js
+++ b/src/twisty/twisty.directive.js
@@ -13,16 +13,27 @@
     'use strict';
     angular
         .module( 'angular-northstar.twisty' )
-        .directive( 'northstarTwisty', ['$timeout', northstarTwisty] );
+        .directive( 'northstarTwisty', ['$compile', northstarTwisty] );
 
-    function northstarTwisty ( $timeout ) {
+    function northstarTwisty ( $compile ) {
         return {
             restrict: 'A',
             link: function ( $scope, element ) {
-                // Wait until next angular cycle before initialising
-                $timeout( function () {
-                    jQuery( element ).twisty();
-                } );
+
+                /*
+                    Initialise the twisty on this element
+                */
+                angular.element( element ).twisty();
+
+                /*
+                    The Northstar JavaScript wraps Twisty widgets in additional HTML, and in the
+                    process it breaks any directives that might have been added to twisty elements
+                    (angular-translate, for example).
+
+                    This line runs $compile on the element contents after the twisty widget has
+                    been initialised, to make sure all of our directives still work
+                */
+                $compile( element.contents() )( $scope );
             }
         };
     }

--- a/src/twisty/twisty.directive.spec.js
+++ b/src/twisty/twisty.directive.spec.js
@@ -13,7 +13,8 @@
 
     var $compile;
     var $scope;
-    var $timeout;
+
+    var element;
 
 
     var getCompiled = function getCompiledElement ( str, scp ) {
@@ -24,34 +25,48 @@
 
     describe( 'Northstar Twisty Directive', function () {
         beforeEach( function () {
+
+            angular.element.fn.twisty = jasmine.createSpy( 'twisty' );
+
             module( 'angular-northstar.twisty' );
 
-            inject( function ( _$compile_, _$rootScope_, _$timeout_ ) {
+            inject( function ( _$compile_, _$rootScope_ ) {
                 $compile = _$compile_;
                 $scope = _$rootScope_;
-                $timeout = _$timeout_;
             } );
 
-            getCompiled( '<span data-widget="twisty" northstar-twisty></span>', $scope );
+            $scope.clickFunction = function clickFunction () {
+                $scope.testBool = true;
+            };
 
-            window.jQuery = function () {};
+            var elementString =
+                '<ul id="testFixture" data-widget="twisty" class="ibm-twisty" northstar-twisty>' +
+                    '<li>' +
+                        '<span class="ibm-twisty-head">' +
+                            '<a id="testFixtureLink" ng-click="clickFunction();">Twisty</a>' +
+                        '</span>' +
+                    '</li>' +
+                '</ul>';
 
-            spyOn( window, 'jQuery' ).and.returnValue( {
-                twisty: function () { return; }
-            } );
+            element = getCompiled( elementString, $scope );
+
         } );
 
-        it( 'must not do anything until the next Angular cycle', function () {
-            expect( window.jQuery )
-                .not.toHaveBeenCalled();
-            console.log( 'test' );
+        it( 'must call the twisty method', function () {
+            expect( angular.element.fn.twisty ).toHaveBeenCalled();
         } );
 
-        it( 'must call the jQuery method after a $timeout', function () {
-            $timeout.flush();
+        it( 'must not break any directives or interactions on the element', function () {
 
-            expect( window.jQuery ).toHaveBeenCalled();
+            expect( $scope.testBool ).toBe( undefined );
+
+            element.find( '#testFixtureLink' ).click();
+
+            $scope.$apply();
+
+            expect( $scope.testBool ).toBe( true );
         } );
     } );
 
 } )();
+


### PR DESCRIPTION
The Northstar JavaScript wraps Twisty widgets in additional HTML, and in the
process it breaks any directives that might have been added to twisty elements
(angular-translate, for example).

This fix runs `$compile` on the element contents after the twisty widget has
been initialised.

Also add jQuery as dev dependency and include in karma config

Update unit test for twisty and add comment to explain functionality